### PR TITLE
update gpu device kernels

### DIFF
--- a/teeny/eagkers/src_device/src/gpu_device.rs
+++ b/teeny/eagkers/src_device/src/gpu_device.rs
@@ -11,15 +11,26 @@ use crate::T;
 }
 
 #[allow(improper_ctypes_definitions)]
-#[kernel] pub unsafe fn saxpy(a: &[T], b: &[T], c: *mut T) {
-  let i = cuda_std::thread::index_1d() as usize;
-  todo!()
+#[kernel] pub unsafe fn saxpy<T>(alpha: T, a: *const T, b: *const T, c: *mut T, n: usize)
+where
+    T : Copy + Mul<Output = T> + Add<Output = T>,
+ {
+  let stride = cuda_std::thread::num_threads_1d() as usize;
+   let mut i = cuda_std::thread::index_1d() as usize;
+   while i < n {
+        *c.add(i) = *a.add(i) * alpha + *b.add(i);
+        i += stride;
+    }
 }
 
 #[allow(improper_ctypes_definitions)]
 #[kernel] pub unsafe fn smul(a: &[T], b: &[T], c: *mut T) {
   let i = cuda_std::thread::index_1d() as usize;
-  todo!()
+  if i < a.len() && i < b.len(){
+    let elem = &mut *c.add(i);
+    *elem = a[i] * b[i];
+  }
+
 }
 
 #[allow(improper_ctypes_definitions)]


### PR DESCRIPTION
## What changed

This updates `teeny/eagkers/src_device/src/gpu_device.rs`.

- implements `smul` as an elementwise multiply kernel using the existing 1D thread index pattern
- replaces the placeholder `saxpy` stub with a generic kernel implementation that uses a grid-stride loop

## Why

The file still contained placeholder GPU kernel implementations. This change starts filling in the device-side kernel logic so the CUDA Rust path is closer to being runnable and inspectable while learning the kernel model.

## Impact

- `smul` now performs useful device work instead of panicking at `todo!()`
- `saxpy` now has an explicit kernel body rather than a placeholder
- the change is isolated to the CUDA device source file

## Validation

- `git diff --check`
- `cargo check --features gpu` could not be run in this shell because `cargo` is not installed in the current environment
